### PR TITLE
Update Symfony debug toolbar link to developer documentation

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/config.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/config.html.twig
@@ -100,8 +100,8 @@
             <div class="sf-toolbar-info-piece">
                 <b>Resources</b>
                 <span>
-                    {% set appVersion = collector.applicationversion|split('.')|join()[:2] %}
-                    <a href="http://doc.prestashop.com/display/PS{{ appVersion }}" rel="help">
+                    {% set appVersion = collector.applicationversion|join()[:3] %}
+                    <a href="https://devdocs.prestashop.com/{{ appVersion }}/" rel="help">
                         Read PrestaShop {{ collector.applicationversion }} Docs
                     </a>
                 </span>
@@ -224,8 +224,8 @@
         <div class="sf-toolbar-info-piece">
           <b>Resources</b>
           <span>
-            {% set appVersion = collector.applicationversion|split('.')|join()[:2] %}
-              <a href="http://doc.prestashop.com/display/PS{{ appVersion }}" rel="help">
+            {% set appVersion = collector.applicationversion|join()[:3] %}
+              <a href="https://devdocs.prestashop.com/{{ appVersion }}/" rel="help">
                   Read PrestaShop {{ collector.applicationversion }} Docs
               </a>
           </span>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Symfony debug toolbar, at the right bottom part there is information about PrestaShop. A link to documentation is provided but it targets doc.prestashop.com instead of devdocs.prestashop.com.<br/><br/>I think the Symfony debug toolbar is a developer tool and consequently this category of users should be redirected to the developer documentation rather than the user documentation.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Expand the bottom right (see screenshot) tab of the Symfony debug toolbar and click on the Documentation link.
| Possible impacts? | Only the Symfony debug toolbar has been modified.

![Capture d’écran 2021-01-26 à 17 07 39](https://user-images.githubusercontent.com/3830050/105870876-03317380-5ff9-11eb-8067-896ecaa96430.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matks/prestashop/9)
<!-- Reviewable:end -->
